### PR TITLE
Run dslc_post_templates_init later

### DIFF
--- a/includes/post-templates.php
+++ b/includes/post-templates.php
@@ -25,4 +25,4 @@
 		foreach ( $dslc_var_templates_pt as $key => $value )
 			$dslc_post_types[] = $key;
 
-	} add_action( 'init', 'dslc_post_templates_init', 1 );
+	} add_action( 'init', 'dslc_post_templates_init', 11 );


### PR DESCRIPTION
Run dslc_post_templates_init at init priority 11 because plugins that register CPT's will often not set priority on init. The default is 10, so it runs at 10 after the dslc_post_templates_init has already run which means we cannot use dslc_post_templates_post_types filter. By setting it to 11 it will usually run after CPT's are registered using default priority. Currently in our plugin (ACF Post Types Pro) we are using priority 0.9 in order to work around this.